### PR TITLE
Update MC264Encoder.java

### DIFF
--- a/android/app/src/main/java/com/arthenica/mobileffmpeg/MC264Encoder.java
+++ b/android/app/src/main/java/com/arthenica/mobileffmpeg/MC264Encoder.java
@@ -294,6 +294,7 @@ public class MC264Encoder {
     private static boolean isRecognizedFormat(int colorFormat) {
         switch (colorFormat) {
             // these are the formats we know how to handle for this test
+            case MediaCodecInfo.CodecCapabilities.COLOR_FormatYUV420Flexible:
             case MediaCodecInfo.CodecCapabilities.COLOR_FormatYUV420Planar:
             case MediaCodecInfo.CodecCapabilities.COLOR_FormatYUV420PackedPlanar:
             case MediaCodecInfo.CodecCapabilities.COLOR_FormatYUV420SemiPlanar:


### PR DESCRIPTION
https://developer.android.com/reference/android/media/MediaCodecInfo.CodecCapabilities#COLOR_FormatYUV420Flexible

에 따라, deprecated되지 않은 YUV420의 Color format도 alias에 추가합니다.